### PR TITLE
Update dependency to fix vulnerability RUSTSEC-2023-0018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,15 +178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rustix"
 version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,16 +235,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
Older versions of `remove_dir_all` have a "Race Condition Enabling Link Following and Time-of-check Time-of-use (TOCTOU) Race Condition". See <https://rustsec.org/advisories/RUSTSEC-2023-0018> for more information on the vulnerability.

Updating the crate `tempfile` to at least version 3.4.0 fixes that, because `tempfile` dropped the dependency on `remove_dir_all` in that version, so `remove_dir_all` is no longer used.